### PR TITLE
Welcome view

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Switch, Redirect  } from 'react-router-dom';
 import Home from "./views/Home/Home"
 import Login from "./views/Login/Login"
+import Welcome from "./views/Welcome/Welcome"
 import NotFound from "./views/NotFound"
 import Header from "./components/Header/Header"
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -16,6 +17,7 @@ const App = () => {
       <div id="main-content-panel">
         <Switch>
           <Route exact path="/login" component={Login} />
+          <Route exact path="/welcome" component={Welcome} />
           <Route exact path="/Home" component={Home} />
           <Route exact path="/">
             <Redirect to="/Home" />

--- a/client/src/views/Welcome/Welcome.js
+++ b/client/src/views/Welcome/Welcome.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './Welcome.css';
+
+function Welcome() {
+    return (
+        <div className='panel container col-xs-12 col-md-3'>
+            
+        </div>
+    );
+}
+
+export default Welcome;

--- a/client/src/views/Welcome/Welcome.js
+++ b/client/src/views/Welcome/Welcome.js
@@ -4,7 +4,20 @@ import './Welcome.css';
 function Welcome() {
     return (
         <div className='panel container col-xs-12 col-md-3'>
-            
+            <h1>Welcome to EstatePlanR!</h1>
+            <form>
+                <div id="question-field">
+                    <label for="estate-plans">Do you have any estate plans?</label>
+                    <select name="estate-plans">
+                        <option value="none">No</option>
+                        <option value="poa">Power of Attorney</option>
+                        <option value="lwill">Living Will</option>
+                        <option value="will">Will</option>
+                        <option value="trust">Trust</option>
+                    </select>
+                </div>
+                <button className="btn btn-primary">Continue</button>
+            </form>
         </div>
     );
 }

--- a/client/src/views/Welcome/Welcome.js
+++ b/client/src/views/Welcome/Welcome.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import Redirect from 'react';
 import './Welcome.css';
 
 function Welcome() {
     return (
         <div className='panel container col-xs-12 col-md-3'>
             <h1>Welcome to EstatePlanR!</h1>
-            <form>
+            <form action="/plans">
                 <div id="question-field">
-                    <label for="estate-plans">Do you have any estate plans?</label>
+                    <label for="estate-plans">Do you already have any estate plans?</label>
                     <select name="estate-plans">
                         <option value="none">No</option>
                         <option value="poa">Power of Attorney</option>


### PR DESCRIPTION
This adds the Welcome view (under client/src/views/Welcome). Checking the file she sent us, this is the only question that needs to be asked before the user selects a plan. Clicking on the Continue button will navigate to /plans with a query string denoting the user selection, so we don't have to go to send it backend. It looks like this. The styling is kept bare for now, but someone can jump on that whenever. 
![image](https://user-images.githubusercontent.com/32201603/68003318-355ff400-fc43-11e9-8dfe-be2943d80eb1.png)
