### PR TITLE
Adds PaymentPlans view and HTML template

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,7 @@ import { Route, Switch, Redirect  } from 'react-router-dom';
 import Home from "./views/Home/Home"
 import Login from "./views/Login/Login"
 import Welcome from "./views/Welcome/Welcome"
+import PaymentPlans from "./views/PaymentPlans/PaymentPlans"
 import NotFound from "./views/NotFound"
 import Header from "./components/Header/Header"
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -18,6 +19,7 @@ const App = () => {
         <Switch>
           <Route exact path="/login" component={Login} />
           <Route exact path="/welcome" component={Welcome} />
+          <Route exact path="/payments" component={PaymentPlans} />
           <Route exact path="/Home" component={Home} />
           <Route exact path="/">
             <Redirect to="/Home" />

--- a/client/src/views/PaymentPlans/PaymentPlans.js
+++ b/client/src/views/PaymentPlans/PaymentPlans.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import Redirect from 'react';
+import './PaymentPlans.css';
+
+function PaymentPlans() {
+    return (
+        <div className="plans-container container col-xs-12 col-md-7">
+            <div className="row">
+                <div className='col-xs-12 col-md-4'>
+                    <div className="panel plan-container">
+                        <h3>Simple</h3>
+                        <span className="currency">$</span><span className="price">10</span><span className="period">/mo</span>
+                        <ul className="featuers-list">
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                        </ul>
+                        <button className="btn btn-outline-primary">Select this plan</button>
+                    </div>
+                </div>
+                <div className='col-xs-12 col-md-4'>
+                    <div className="panel plan-container">
+                        <h3>Advanced</h3>
+                        <span className="currency">$</span><span className="price">20</span><span className="period">/mo</span>
+                        <ul className="featuers-list">
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                        </ul>
+                        <button className="btn btn-primary">Select this plan</button>
+                    </div>
+                </div>
+                <div className='col-xs-12 col-md-4'>
+                    <div className="panel plan-container">
+                        <h3>Comprehensive</h3>
+                        <span className="currency">$</span><span className="price">30</span><span className="period">/mo</span>
+                        <ul className="featuers-list">
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                            <li>Short desc of feature</li>
+                        </ul>
+                        <button className="btn btn-primary">Select this plan</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default PaymentPlans;


### PR DESCRIPTION
I added the next view for our HTML templates: the payment plan selector. This includes the HTML template with only default styling (PaymentPlans.css) is empty. We can focus on styling as a later issue or on a later sprint, since were just trying to knock these out. You can visit this page by running npm start in the client directory and navigating to http://localhost:3000/payments. This is what it looks like
![image](https://user-images.githubusercontent.com/32201603/68089747-39a23200-fe3a-11e9-87fb-e83810eb4da8.png)
